### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/Parser.php
+++ b/Parser.php
@@ -1,9 +1,9 @@
 <?php
 namespace robertgrubb\assetConverter;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
-abstract class Parser extends Object
+abstract class Parser extends BaseObject
 {
     /**
      * Parse a asset file.


### PR DESCRIPTION
"Object" is a reserved word in PHP 7.2, so it cannot be longer used as a base class for app classes, Yii 2.0.13 provides alternative BaseObject base class.